### PR TITLE
Feat/filter and navigation

### DIFF
--- a/src/components/specific/history/FilterControls.tsx
+++ b/src/components/specific/history/FilterControls.tsx
@@ -7,37 +7,54 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
   uniqueGroups,
   selectedGroup,
   onGroupChange,
+  sortOptions, // 추가
+  sortOption, // 추가
+  onSortChange, // 추가
   filteredCount,
 }) => {
   const [isGroupOpen, setIsGroupOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [isSortOpen, setIsSortOpen] = useState(false); // 추가
+  
+  const groupDropdownRef = useRef<HTMLDivElement>(null);
+  const sortDropdownRef = useRef<HTMLDivElement>(null); // 추가
 
   // 드롭다운 외부 클릭 시 닫기
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
       if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(event.target as Node)
+        groupDropdownRef.current &&
+        !groupDropdownRef.current.contains(event.target as Node)
       ) {
         setIsGroupOpen(false);
+      }
+      if (
+        sortDropdownRef.current &&
+        !sortDropdownRef.current.contains(event.target as Node)
+      ) {
+        setIsSortOpen(false);
       }
     };
     document.addEventListener('mousedown', handleClickOutside);
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [dropdownRef]);
+  }, [groupDropdownRef, sortDropdownRef]);
 
   const handleGroupSelect = (group: string) => {
-    onGroupChange(group); // 부모 컴포넌트에 변경 알림
-    setIsGroupOpen(false); // 드롭다운 닫기
+    onGroupChange(group);
+    setIsGroupOpen(false);
+  };
+
+  const handleSortSelect = (sort: string) => {
+    onSortChange(sort);
+    setIsSortOpen(false);
   };
 
   return (
     <div className="mt-10 flex w-full flex-wrap items-center justify-between gap-4">
       <div className="flex items-center gap-4">
         {/* --- 그룹 필터 (드롭다운) --- */}
-        <div className="relative" ref={dropdownRef}>
+        <div className="relative" ref={groupDropdownRef}>
           <div className="flex items-center gap-2">
             <span className="text-sm text-gray-600">그룹:</span>
             <button
@@ -58,8 +75,8 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
                   onClick={() => handleGroupSelect(group)}
                   className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm font-medium ${
                     selectedGroup === group
-                      ? 'text-white' // 선택된 항목
-                      : 'text-gray-300' // 미선택 항목
+                      ? 'text-white'
+                      : 'text-gray-300'
                   } hover:bg-indigo-500 hover:text-white`}
                 >
                   <div className="w-5">
@@ -72,14 +89,43 @@ export const FilterControls: React.FC<FilterControlsProps> = ({
           )}
         </div>
 
-        {/* --- 정렬 필터 --- */}
-        <div className="flex items-center gap-2">
-          <span className="text-sm text-gray-600">정렬:</span>
-          <button className="flex items-center gap-1 rounded-md border border-gray-300 bg-white px-2.5 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50">
-            최신순 <ChevronDownIcon />
-          </button>
+        {/* --- 정렬 필터 (드롭다운) --- */}
+        <div className="relative" ref={sortDropdownRef}>
+          <div className="flex items-center gap-2">
+            <span className="text-sm text-gray-600">정렬:</span>
+            <button
+              onClick={() => setIsSortOpen(!isSortOpen)}
+              className="flex w-28 items-center justify-between gap-1 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50"
+            >
+              <span>{sortOption}</span>
+              <ChevronDownIcon />
+            </button>
+          </div>
+
+          {/* 드롭다운 메뉴 */}
+          {isSortOpen && (
+            <div className="absolute z-10 mt-2 w-full rounded-lg bg-gray-800 p-2 shadow-lg">
+              {sortOptions.map((sort) => (
+                <button
+                  key={sort}
+                  onClick={() => handleSortSelect(sort)}
+                  className={`flex w-full items-center gap-3 rounded-md px-3 py-2 text-left text-sm font-medium ${
+                    sortOption === sort
+                      ? 'text-white'
+                      : 'text-gray-300'
+                  } hover:bg-indigo-500 hover:text-white`}
+                >
+                  <div className="w-5">
+                    {sortOption === sort && <SelectCheckIcon />}
+                  </div>
+                  <span>{sort}</span>
+                </button>
+              ))}
+            </div>
+          )}
         </div>
       </div>
+      
       <div className="text-sm text-gray-500">
         총 {filteredCount}개의 모임 기록
       </div>

--- a/src/components/specific/history/dateUtils.tsx
+++ b/src/components/specific/history/dateUtils.tsx
@@ -1,0 +1,19 @@
+export const parseKoreanDate = (dateString: string): Date => {
+  const match = dateString.match(/(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/);
+  if (match) {
+    const [, year, month, day] = match;
+    return new Date(parseInt(year), parseInt(month) - 1, parseInt(day));
+  }
+  return new Date(0); // 파싱 실패 시 기본값
+};
+
+export const compareDates = (
+  dateA: string,
+  dateB: string,
+  order: 'asc' | 'desc' = 'desc'
+): number => {
+  const timeA = parseKoreanDate(dateA).getTime();
+  const timeB = parseKoreanDate(dateB).getTime();
+  
+  return order === 'desc' ? timeB - timeA : timeA - timeB;
+};

--- a/src/pages/GroupCreatePage.tsx
+++ b/src/pages/GroupCreatePage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import {
   PlusIcon, UsersIcon, ClockIcon, LocationIcon, CheckIcon
 } from '../components/icons';
@@ -9,9 +10,12 @@ import GroupCreateSuccess from '../components/group/GroupCreateSuccess';
 type Tab = 'create' | 'join';
 
 export default function GroupCreatePage() {
-  const [tab, setTab] = useState<Tab>('create');
+  const [searchParams] = useSearchParams(); 
 
-  // 성공 상태를 페이지에서 관리
+  // URL 파라미터에서 tab 값 읽어오기
+  const initialTab = (searchParams.get('tab') === 'join' ? 'join' : 'create') as Tab;
+  const [tab, setTab] = useState<Tab>(initialTab); // 초기값 설정
+
   const [success, setSuccess] = useState<{ id: string; name: string; inviteCode: string } | null>(null);
 
   return (

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -4,6 +4,7 @@ import { HistoryHeader } from '../components/specific/history/HistoryHeader';
 import { StatsSection } from '../components/specific/history/StatsSection';
 import { FilterControls } from '../components/specific/history/FilterControls';
 import { MeetingList } from '../components/specific/history/MeetingList';
+import { compareDates } from '../components/specific/history/dateUtils';
 import { DUMMY_MEETINGS } from '../constants/mockData';
 
 export default function HistoryPage() {
@@ -20,29 +21,33 @@ export default function HistoryPage() {
 
   const sortOptions = ['최신순', '오래된순', '완료', '미완료'];
 
+  // 그룹 필터링
   const filteredByGroup = DUMMY_MEETINGS.filter((meeting) =>
     selectedGroup === '전체' ? true : meeting.title === selectedGroup
   );
 
-  const filteredMeetings = [...filteredByGroup].filter((meeting) => {
-    // 상태 필터링
-    if (sortOption === '완료') {
-      return meeting.status === '100% 완료';
-    }
-    if (sortOption === '미완료') {
-      return meeting.status !== '100% 완료';
-    }
-    return true;
-  }).sort((a, b) => {
-    // 날짜 정렬 (날짜 형식: "2024.01.15")
-    if (sortOption === '최신순') {
-      return b.date.localeCompare(a.date);
-    }
-    if (sortOption === '오래된순') {
-      return a.date.localeCompare(b.date);
-    }
-    return 0;
-  });
+  // 정렬 필터링
+  const filteredMeetings = [...filteredByGroup]
+    .filter((meeting) => {
+      // 상태 필터링
+      if (sortOption === '완료') {
+        return meeting.status === '100% 완료';
+      }
+      if (sortOption === '미완료') {
+        return meeting.status !== '100% 완료';
+      }
+      return true;
+    })
+    .sort((a, b) => {
+      // 날짜 정렬
+      if (sortOption === '최신순') {
+        return compareDates(a.date, b.date, 'desc');
+      }
+      if (sortOption === '오래된순') {
+        return compareDates(a.date, b.date, 'asc');
+      }
+      return 0;
+    });
 
   return (
     <section className="bg-gray-50 py-12 min-h-screen">

--- a/src/pages/HistoryPage.tsx
+++ b/src/pages/HistoryPage.tsx
@@ -9,6 +9,7 @@ import { DUMMY_MEETINGS } from '../constants/mockData';
 export default function HistoryPage() {
   const navigate = useNavigate();
   const [selectedGroup, setSelectedGroup] = useState('전체');
+  const [sortOption, setSortOption] = useState('최신순');
 
   const handleGoHome = () => navigate('/');
 
@@ -17,9 +18,31 @@ export default function HistoryPage() {
     ...new Set(DUMMY_MEETINGS.map((meeting) => meeting.title)),
   ];
 
-  const filteredMeetings = DUMMY_MEETINGS.filter((meeting) =>
+  const sortOptions = ['최신순', '오래된순', '완료', '미완료'];
+
+  const filteredByGroup = DUMMY_MEETINGS.filter((meeting) =>
     selectedGroup === '전체' ? true : meeting.title === selectedGroup
   );
+
+  const filteredMeetings = [...filteredByGroup].filter((meeting) => {
+    // 상태 필터링
+    if (sortOption === '완료') {
+      return meeting.status === '100% 완료';
+    }
+    if (sortOption === '미완료') {
+      return meeting.status !== '100% 완료';
+    }
+    return true;
+  }).sort((a, b) => {
+    // 날짜 정렬 (날짜 형식: "2024.01.15")
+    if (sortOption === '최신순') {
+      return b.date.localeCompare(a.date);
+    }
+    if (sortOption === '오래된순') {
+      return a.date.localeCompare(b.date);
+    }
+    return 0;
+  });
 
   return (
     <section className="bg-gray-50 py-12 min-h-screen">
@@ -30,6 +53,9 @@ export default function HistoryPage() {
           uniqueGroups={uniqueGroups}
           selectedGroup={selectedGroup}
           onGroupChange={setSelectedGroup}
+          sortOptions={sortOptions} 
+          sortOption={sortOption}
+          onSortChange={setSortOption} 
           filteredCount={filteredMeetings.length}
         />
         <MeetingList meetings={filteredMeetings} />

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -10,7 +10,7 @@ export default function MainPage() {
     };
 
     const handleJoinGroup = () => {
-        // navigate(''); // 추후 그룹 참여 페이지 연결 예정
+        navigate('/groups/new?tab=join'); 
     };
 
     return (

--- a/src/types/history.ts
+++ b/src/types/history.ts
@@ -36,6 +36,9 @@ export interface FilterControlsProps {
   uniqueGroups: string[];
   selectedGroup: string;
   onGroupChange: (group: string) => void;
+  sortOptions: string[]; 
+  sortOption: string; 
+  onSortChange: (sort: string) => void;
   filteredCount: number;
 }
 


### PR DESCRIPTION
1. 페이지 간 연결 개선
 - 메인 페이지에서 "그룹 참여하기" 버튼 클릭 시, query parameter(?tab=join)로 그룹 생성 페이지의 참여 탭으로 이동
 - MainPage.tsx: handleJoinGroup 함수에 navigate 경로 추가

2. 히스토리 페이지 정렬 기능 추가
- 정렬 드롭다운 구현(최신순/오래된순/완료/미완료)
- 날짜 기반 정렬 로직 구현(문자열 Date 객체로 변환) -> dateUtils.tsx에 별도 파일로 분리